### PR TITLE
this sample is for websql?

### DIFF
--- a/src/doc/sampleapp/tips/storage.rst
+++ b/src/doc/sampleapp/tips/storage.rst
@@ -10,7 +10,7 @@ HTML5 Web SQL Database connects to the device database. This section describes W
 Web SQL Database
 ==========================
 
-You need to create a new Database object before accessing to it. *window.openDatabase* function creates a new SQLite database. 
+You need to create a new Database object before accessing to it. *window.openDatabase* function creates a new Web SQL database.
 
 .. code-block:: javascript
 
@@ -18,7 +18,7 @@ You need to create a new Database object before accessing to it. *window.openDat
 
 
 ------------------------------------------------------
-Creating a Database (SQLite)
+Creating a Database (Web SQL)
 ------------------------------------------------------
 
 ::
@@ -87,7 +87,7 @@ rows                            Returns *ResultSetRowList* object. It represents
 
 
 ---------------------------------------------------------------------------
-Executing SQL (SQLite)
+Executing SQL (Web SQL)
 ---------------------------------------------------------------------------
 
 .. literalinclude:: download/storage/en/index.html


### PR DESCRIPTION
The examples on this page:

https://docs.monaca.io/en/sampleapp/tips/storage/

is for WebSQL and not for SQLite correct?

p.s. Would be great to have an SQLite example using cordova-plugin-sqlite-2 or cordova-sqlite-storage